### PR TITLE
implemented user sign-up page using clerk auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ CLERK_SECRET_KEY=
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
 NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
+NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL=/explore
 
 # For Docker setup (local PostgreSQL)
 DATABASE_URL=postgresql://hackmate:hackmate_password@postgres:5432/hackmate?schema=public

--- a/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from '@clerk/nextjs'
+
+export default function Page() {
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+			<SignUp />
+		</div>
+	)
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)',"/"])
+const isPublicRoute = createRouteMatcher(['/sign-in(.*)',"/", "/sign-up(.*)"])
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {


### PR DESCRIPTION
## Description
Implemented user sign-up page leveraging clerk auth

## Related Issues
Closes #10 

## Changes Made
- Added signup redirect url to env so after signup user is redirected to `/explore`
- Implemented sign up using clerk auth
- Added `/sign-up` as a public route

## Checklist
- [x] Code follows the style guide
- [x] Lint and tests pass locally
- [ ] I’ve added or updated tests
- [ ] I’ve updated the README or docs if needed
